### PR TITLE
fix: wrap texts in paragraphs in blocks

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -622,6 +622,16 @@ function decorateBlock(block) {
     blockWrapper.classList.add(`${shortBlockName}-wrapper`);
     const section = block.closest('.section');
     if (section) section.classList.add(`${shortBlockName}-container`);
+    block.querySelectorAll(':scope > div > div').forEach((cell) => {
+      if (cell.textContent.trim()) {
+        const firstChild = cell.firstElementChild;
+        if (!firstChild || ['STRONG', 'EM', 'A'].includes(firstChild.tagName)) {
+          const p = document.createElement('p');
+          p.append(...cell.childNodes);
+          cell.replaceChildren(p);
+        }
+      }
+    });
   }
 }
 


### PR DESCRIPTION
Currently the `<p>` of text paragraphs in block cells are removed, which is semantically incorrect. This is a known issue in the helix-html-pipeline which has yet to be addressed. In the meantime, wrap any "plain" text (`<a>`, `<strong>`, `<em>`, `#text`) in a `<p>` as part of the decoration phase. Skip h1-6 as those are already semantically correct.

- Before: https://main--aem-boilerplate-xwalk--adobe-rnd.hlx.page/drafts/drudolph/cards-block
- After: https://wrap-pars-in-blocks--aem-boilerplate-xwalk--adobe-rnd.hlx.page/drafts/drudolph/cards-block