### PR TITLE
fix: allow to call decorate sections more than once

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -428,7 +428,7 @@ function decorateIcons(element, prefix = '') {
  * @param {Element} main The container element
  */
 function decorateSections(main) {
-  main.querySelectorAll(':scope > div').forEach((section) => {
+  main.querySelectorAll(':scope > div:not([data-section-status])').forEach((section) => {
     const wrappers = [];
     let defaultContent = false;
     [...section.children].forEach((e) => {


### PR DESCRIPTION
To support in-place updates of sections we need to be able to call `decorateSections()` more than once. 

Currently `decorateSections()` is stateful, meaning it breaks the page as it applies its changes to the DOM twice. With this proposal `decorateSections()` will only handle sections that have not yet been decorated. 