### PR TITLE
feat: in-context editable blocks

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -1,12 +1,12 @@
 import { createOptimizedPicture } from '../../scripts/aem.js';
-import { moveAttributes } from '../../scripts/scripts.js';
+import { moveInstrumentation } from '../../scripts/scripts.js';
 
 export default function decorate(block) {
   /* change to ul, li */
   const ul = document.createElement('ul');
   [...block.children].forEach((row) => {
     const li = document.createElement('li');
-    moveAttributes(row, li);
+    moveInstrumentation(row, li);
     while (row.firstElementChild) li.append(row.firstElementChild);
     [...li.children].forEach((div) => {
       if (div.children.length === 1 && div.querySelector('picture')) div.className = 'cards-card-image';
@@ -16,7 +16,7 @@ export default function decorate(block) {
   });
   ul.querySelectorAll('img').forEach((img) => {
     const optimizedPic = createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }]);
-    moveAttributes(img, optimizedPic.querySelector('img'), ['data-aue-prop', 'data-aue-label', 'data-aue-filter']);
+    moveInstrumentation(img, optimizedPic.querySelector('img'));
     img.closest('picture').replaceWith(optimizedPic);
   });
   block.textContent = '';

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -1,13 +1,12 @@
 import { createOptimizedPicture } from '../../scripts/aem.js';
+import { moveAttributes } from '../../scripts/scripts.js';
 
 export default function decorate(block) {
   /* change to ul, li */
   const ul = document.createElement('ul');
   [...block.children].forEach((row) => {
     const li = document.createElement('li');
-    [...row.attributes].forEach(({ nodeName, nodeValue }) => {
-      li.setAttribute(nodeName, nodeValue);
-    });
+    moveAttributes(row, li);
     while (row.firstElementChild) li.append(row.firstElementChild);
     [...li.children].forEach((div) => {
       if (div.children.length === 1 && div.querySelector('picture')) div.className = 'cards-card-image';
@@ -15,7 +14,11 @@ export default function decorate(block) {
     });
     ul.append(li);
   });
-  ul.querySelectorAll('img').forEach((img) => img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
+  ul.querySelectorAll('img').forEach((img) => {
+    const optimizedPic = createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }]);
+    moveAttributes(img, optimizedPic.querySelector('img'), ['data-aue-prop', 'data-aue-label', 'data-aue-filter']);
+    img.closest('picture').replaceWith(optimizedPic);
+  });
   block.textContent = '';
   block.append(ul);
 }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -633,7 +633,9 @@ function decorateBlock(block) {
         [...cell.attributes]
           // move the instrumentation from the cell to the new paragraph, also keep the class
           // in case the content is a buttton and the cell the button-container
-          .filter(({ nodeName }) => nodeName === 'class' || nodeName.startsWith('data-aue'))
+          .filter(({ nodeName }) => nodeName === 'class'
+            || nodeName.startsWith('data-aue')
+            || nodeName.startsWith('data-richtext'))
           .forEach(({ nodeName, nodeValue }) => {
             paragraph.setAttribute(nodeName, nodeValue);
             cell.removeAttribute(nodeName);

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -630,10 +630,20 @@ function decorateBlock(block) {
         || (firstChild && !firstChild.tagName.match(/^(P(RE)?|H[1-6]|(U|O)L|TABLE)$/))) {
         const tag = firstChild && firstChild.tagName === 'CODE' && cellText === firstChild.textContent.trim() ? 'pre' : 'p';
         const paragraph = document.createElement(tag);
+        [...cell.attributes]
+          // move the instrumentation from the cell to the new paragraph, also keep the class
+          // in case the content is a buttton and the cell the button-container
+          .filter(({ nodeName }) => nodeName === 'class' || nodeName.startsWith('data-aue'))
+          .forEach(({ nodeName, nodeValue }) => {
+            paragraph.setAttribute(nodeName, nodeValue);
+            cell.removeAttribute(nodeName);
+          });
         paragraph.append(...cell.childNodes);
         cell.replaceChildren(paragraph);
       }
     });
+    // eslint-disable-next-line no-use-before-define
+    decorateButtons(block);
   }
 }
 

--- a/scripts/editor-support-rte.js
+++ b/scripts/editor-support-rte.js
@@ -1,0 +1,65 @@
+/* eslint-disable no-cond-assign */
+/* eslint-disable import/prefer-default-export */
+
+// group editable texts in single wrappers if applicable.
+// this script should execute after script.js but before the the universal editor cors script
+// and any block being loaded
+
+export function decorateRichtext(container = document) {
+  function deleteInstrumentation(element) {
+    delete element.dataset.richtextResource;
+    delete element.dataset.richtextProp;
+    delete element.dataset.richtextFilter;
+    delete element.dataset.richtextLabel;
+  }
+
+  let element;
+  while (element = container.querySelector('[data-richtext-prop]:not(div)')) {
+    const {
+      richtextResource,
+      richtextProp,
+      richtextFilter,
+      richtextLabel,
+    } = element.dataset;
+    deleteInstrumentation(element);
+    const siblings = [];
+    let sibling = element;
+    while (sibling = sibling.nextElementSibling) {
+      if (sibling.dataset.richtextResource === richtextResource
+        && sibling.dataset.richtextProp === richtextProp) {
+        deleteInstrumentation(sibling);
+        siblings.push(sibling);
+      } else break;
+    }
+    let orphanElements;
+    if (richtextResource && richtextProp) {
+      orphanElements = document.querySelectorAll(`[data-richtext-id="${richtextResource}"][data-richtext-prop="${richtextProp}"]`);
+    } else {
+      const editable = element.closest('[data-aue-resource]');
+      if (editable) {
+        orphanElements = editable.querySelectorAll(`[data-richtext-prop="${richtextProp}"]`);
+      } else {
+        console.warn(`Editable parent not found or richtext property ${richtextProp}`);
+        return;
+      }
+    }
+
+    if (orphanElements.length) {
+      console.warn('Found orphan elements of a richtext, that were not consecutive siblings of '
+        + 'the first paragraph', orphanElements);
+      orphanElements.forEach((orphanElement) => deleteInstrumentation(orphanElement));
+    } else {
+      const group = document.createElement('div');
+      if (richtextResource) group.dataset.aueResource = richtextResource;
+      if (richtextProp) group.dataset.aueProp = richtextProp;
+      if (richtextLabel) group.dataset.aueLabel = richtextLabel;
+      if (richtextFilter) group.dataset.aueFilter = richtextFilter;
+      group.dataset.aueBehavior = 'component';
+      group.dataset.aueType = 'richtext';
+      element.replaceWith(group);
+      group.append(element, ...siblings);
+    }
+  }
+}
+
+decorateRichtext();

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -7,7 +7,6 @@ import {
   loadBlock,
   loadBlocks,
 } from './aem.js';
-// eslint-disable-next-line import/no-unresolved
 import { decorateRichtext } from './editor-support-rte.js';
 import { decorateMain } from './scripts.js';
 

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -51,8 +51,8 @@ async function applyChanges(event) {
         block.insertAdjacentElement('afterend', newBlock);
         decorateButtons(newBlock);
         decorateIcons(newBlock);
-        decorateRichtext(newBlock);
         decorateBlock(newBlock);
+        decorateRichtext(newBlock);
         await loadBlock(newBlock);
         block.remove();
         newBlock.style.display = null;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -28,7 +28,7 @@ export function moveAttributes(from, to, attributes) {
     const value = from.getAttribute(attr);
     if (value) {
       to.setAttribute(attr, value);
-      from.removeAttribute(value);
+      from.removeAttribute(attr);
     }
   });
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -34,6 +34,21 @@ export function moveAttributes(from, to, attributes) {
 }
 
 /**
+ * Move instrumentation attributes from a given element to another given element.
+ * @param {Element} from the element to copy attributes from
+ * @param {Element} to the element to copy attributes to
+ */
+export function moveInstrumentation(from, to) {
+  moveAttributes(
+    from,
+    to,
+    [...from.attributes]
+      .map(({ nodeName }) => nodeName)
+      .filter((attr) => attr.startsWith('data-aue-') || attr.startsWith('data-richtext-')),
+  );
+}
+
+/**
  * load fonts.css and set a session storage flag
  */
 async function loadFonts() {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -15,6 +15,25 @@ import {
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
 /**
+ * Moves all the attributes from a given elmenet to another given element.
+ * @param {Element} from the element to copy attributes from
+ * @param {Element} to the element to copy attributes to
+ */
+export function moveAttributes(from, to, attributes) {
+  if (!attributes) {
+    // eslint-disable-next-line no-param-reassign
+    attributes = [...from.attributes].map(({ nodeName }) => nodeName);
+  }
+  attributes.forEach((attr) => {
+    const value = from.getAttribute(attr);
+    if (value) {
+      to.setAttribute(attr, value);
+      from.removeAttribute(value);
+    }
+  });
+}
+
+/**
  * load fonts.css and set a session storage flag
  */
 async function loadFonts() {


### PR DESCRIPTION
This adds support for fully instrumented blocks for in-context editing. 

- instrumentation preserved when wrapping non-block content in cells into a `<p>` or `<pre>`
- buttons consistently decorated in blocks
- instrumentation preserved in cards.js
