### PR TITLE
feat: Forms embed component for XWalk

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -51,6 +51,20 @@
               }
             }
           }
+        },
+        {
+          "title": "Adaptive Form - Embed",
+          "id": "embedform",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/embedform/v1/embedform",
+                "template": {
+                  "formPath": ""
+                }
+              }
+            }
+          }
         }
       ]
     },

--- a/component-definition.json
+++ b/component-definition.json
@@ -138,14 +138,14 @@
         },
         {
           "title": "Adaptive Form - Embed",
-          "id": "form",
+          "id": "formembed",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
                   "name": "Form",
-                  "model": "form"
+                  "model": "formembed"
                 }
               }
             }

--- a/component-definition.json
+++ b/component-definition.json
@@ -51,20 +51,6 @@
               }
             }
           }
-        },
-        {
-          "title": "Adaptive Form - Embed",
-          "id": "embedform",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/franklin/components/embedform/v1/embedform",
-                "template": {
-                  "formPath": ""
-                }
-              }
-            }
-          }
         }
       ]
     },
@@ -145,6 +131,21 @@
                 "template": {
                   "name": "Card",
                   "model": "card"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Adaptive Form - Embed",
+          "id": "form",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Form",
+                  "model": "form"
                 }
               }
             }

--- a/component-filters.json
+++ b/component-filters.json
@@ -27,7 +27,8 @@
       "title",
       "hero",
       "cards",
-      "columns"
+      "columns",
+      "form"
     ]
   },
   {

--- a/component-filters.json
+++ b/component-filters.json
@@ -28,7 +28,7 @@
       "hero",
       "cards",
       "columns",
-      "form"
+      "formembed"
     ]
   },
   {

--- a/component-models.json
+++ b/component-models.json
@@ -187,10 +187,10 @@
     ]
   },
   {
-    "id": "embedform",
+    "id": "form",
     "fields": [
       {
-        "component": "text-input",
+        "component": "text",
         "valueType": "string",
         "name": "formPath",
         "value": "",

--- a/component-models.json
+++ b/component-models.json
@@ -187,7 +187,7 @@
     ]
   },
   {
-    "id": "form",
+    "id": "formembed",
     "fields": [
       {
         "component": "text",

--- a/component-models.json
+++ b/component-models.json
@@ -185,5 +185,17 @@
         "valueType": "string"
       }
     ]
+  },
+  {
+    "id": "embedform",
+    "fields": [
+      {
+        "component": "text-input",
+        "valueType": "string",
+        "name": "formPath",
+        "value": "",
+        "label": "Form Path"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This PR provides ability to UE site author to embed Form inside a site page. Form can be a doc-based form (Sharepoint Excel or Google Drive) or AEM authored AF2 form.

Current approach uses the generic block component with one text field to input form URL (sheet based) / path (AF2).

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.hlx.live/
- After: https://main--xwalk-sites--akasjain-helix.hlx.page/content/franklin-examples/review
