### PR TITLE
fix: header/footer fragment loading

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -10,7 +10,7 @@ export default async function decorate(block) {
   block.textContent = '';
 
   // load footer fragment
-  const footerPath = footerMeta.footer || '/footer';
+  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/footer';
   const fragment = await loadFragment(footerPath);
 
   // decorate footer DOM

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -93,7 +93,7 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
 export default async function decorate(block) {
   // load nav as fragment
   const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta).pathname : '/nav';
+  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
   const fragment = await loadFragment(navPath);
 
   // decorate nav DOM


### PR DESCRIPTION
For crosswalk we often use paths to load header and footer fragments. 

In oder to use them with `new URL()` we have to provide a URL or Location object as base.


Test URLs:
- Before: https://main--aem-boilerplate-xwalk--adobe-rnd.hlx.live/drafts/drudolph/cards-block
- After: https://fix-header-footer--aem-boilerplate-xwalk--adobe-rnd.hlx.live/drafts/drudolph/cards-block
