### PR TITLE
SITES-16562 - [Xwalk] Open Universal Editor from Franklin Sidekick

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,6 +11,7 @@ import {
   loadBlocks,
   loadCSS,
 } from './aem.js';
+import { initSidekick } from './sidekick.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
@@ -142,6 +143,7 @@ function loadDelayed() {
   // eslint-disable-next-line import/no-cycle
   window.setTimeout(() => import('./delayed.js'), 3000);
   // load anything that can be postponed to the latest here
+  initSidekick();
 }
 
 async function loadPage() {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,7 +11,6 @@ import {
   loadBlocks,
   loadCSS,
 } from './aem.js';
-import { initSidekick } from './sidekick.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
@@ -143,7 +142,7 @@ function loadDelayed() {
   // eslint-disable-next-line import/no-cycle
   window.setTimeout(() => import('./delayed.js'), 3000);
   // load anything that can be postponed to the latest here
-  initSidekick();
+  import('./sidekick.js').then(({ initSidekick }) => initSidekick());
 }
 
 async function loadPage() {

--- a/scripts/sidekick.js
+++ b/scripts/sidekick.js
@@ -1,0 +1,62 @@
+async function getContentSourceUrl(owner, repo, ref) {
+  const res = await fetch(`https://admin.hlx.page/sidekick/${owner}/${repo}/${ref}/env.json`);
+  if (!res || !res.ok) {
+    return null;
+  }
+  const env = await res.json();
+  if (!env) {
+    return null;
+  }
+  return env.contentSourceUrl;
+}
+async function openAemEditor(event) {
+  const { owner, repo, ref } = event.detail.data.config;
+  const contentSourceUrl = await getContentSourceUrl(owner, repo, ref);
+  const path = window.location.pathname;
+  const editorUrl = `${contentSourceUrl}${path}?cmd=open`;
+  // open the editor in a new tab
+  window.open(editorUrl, '_blank');
+}
+
+function getButton(sk, selector) {
+  let btn = sk.shadowRoot.querySelector(selector);
+  if (btn) {
+    return btn;
+  }
+  return new Promise((resolve) => {
+    const check = () => {
+      btn = sk.shadowRoot.querySelector(selector);
+      if (btn) {
+        resolve(btn);
+      } else {
+        setTimeout(check, 100);
+      }
+    };
+    check();
+  });
+}
+
+async function overrideEditButton(sk) {
+  const oldEditBtn = await getButton(sk, '.edit.plugin');
+  const newEditBtn = await getButton(sk, '.aemedit.plugin');
+  oldEditBtn.replaceWith(newEditBtn);
+  // hack to remove the original edit button that is generated again in the DOM
+  const oldEditBtn1 = await getButton(sk, '.edit.plugin');
+  oldEditBtn1.remove();
+  sk.addEventListener('custom:aemedit', openAemEditor);
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export function initSidekick() {
+  let sk = document.querySelector('helix-sidekick');
+  if (sk) {
+    // sidekick already loaded
+    overrideEditButton(sk);
+  } else {
+    // wait for sidekick to be loaded
+    document.addEventListener('sidekick-ready', () => {
+      sk = document.querySelector('helix-sidekick');
+      overrideEditButton(sk);
+    }, { once: true });
+  }
+}

--- a/scripts/sidekick.js
+++ b/scripts/sidekick.js
@@ -14,17 +14,14 @@ async function openWithUniversalEditor(event) {
     console.error('Content source URL not found');
     return;
   }
-  const path = window.location.pathname;
-  const editorUrl = `${contentSourceUrl}${path}?cmd=open`;
+  const { pathname } = window.location;
+  const editorUrl = `${contentSourceUrl}${pathname}?cmd=open`;
   // open the editor in a new tab
   window.open(editorUrl, '_blank');
 }
 
-function getElement(sk, selector) {
+async function getElement(sk, selector) {
   let elt = sk.shadowRoot.querySelector(selector);
-  if (elt) {
-    return elt;
-  }
   return new Promise((resolve) => {
     const check = () => {
       elt = sk.shadowRoot.querySelector(selector);

--- a/scripts/sidekick.js
+++ b/scripts/sidekick.js
@@ -39,8 +39,9 @@ async function customizeButtons(sk) {
   // hide the default buttons
   const container = await getElement(sk, '.plugin-container');
   container.style.visibility = 'hidden';
-  for (let i = 0; i < ['edit', 'reload', 'publish', 'delete', 'unpublish'].length; i += 1) {
-    const action = ['edit', 'reload', 'publish', 'delete', 'unpublish'][i];
+  const actions = ['edit', 'reload', 'publish', 'delete', 'unpublish'];
+  for (let i = 0; i < actions.length; i += 1) {
+    const action = actions[i];
     // eslint-disable-next-line no-await-in-loop
     const btn = await getElement(sk, `.${action}.plugin`);
     btn.style.display = 'none';

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    {
+      "id": "aemedit",
+      "title": "Edit",
+      "environments": [ "dev", "preview", "live" ],
+      "event": "aemedit"
+    }
+  ]
+}


### PR DESCRIPTION
- adds a customized Edit button to the Sidekick to open the page with the Universal Editor
- hides the default buttons of the Sidekick

Fix [SITES-16562](https://jira.corp.adobe.com/browse/SITES-16562)

Test URLs:
- Before: https://main--aem-boilerplate-xwalk--jckautzmann.hlx.page/
- After: https://open-ue--aem-boilerplate-xwalk--jckautzmann.hlx.page/

Example:
![Screenshot 2024-04-17 at 18 02 28](https://github.com/adobe-rnd/aem-boilerplate-xwalk/assets/6152300/a7606ac2-6360-4dcd-af49-1f9af088c4d7)

