### PR TITLE
fix: treat RTE wrappers as default content

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -459,10 +459,10 @@ function decorateSections(main) {
     const wrappers = [];
     let defaultContent = false;
     [...section.children].forEach((e) => {
-      if (e.tagName === 'DIV' || !defaultContent) {
+      if ((e.tagName === 'DIV' && e.className) || !defaultContent) {
         const wrapper = document.createElement('div');
         wrappers.push(wrapper);
-        defaultContent = e.tagName !== 'DIV';
+        defaultContent = e.tagName !== 'DIV' || !e.className;
         if (defaultContent) wrapper.classList.add('default-content-wrapper');
       }
       wrappers[wrappers.length - 1].append(e);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #32 

Test URLs:
- Before: https://main--aem-boilerplate-xwalk--adobe-rnd.hlx.live/
- After: https://rte-wrappers-as-default-content--aem-boilerplate-xwalk--adobe-rnd.hlx.live/
