### PR TITLE
Reuse model field definitions across multiple blocks

### DIFF
--- a/blocks/hero/_hero.json
+++ b/blocks/hero/_hero.json
@@ -40,6 +40,9 @@
           "value": "",
           "label": "Text",
           "valueType": "string"
+        },
+        {
+         "...": "../../models/_common.json#/button-fields"
         }
       ]
     }

--- a/component-models.json
+++ b/component-models.json
@@ -182,6 +182,40 @@
         "value": "",
         "label": "Text",
         "valueType": "string"
+      },
+      {
+        "component": "aem-content",
+        "name": "link",
+        "label": "Link"
+      },
+      {
+        "component": "text",
+        "name": "linkText",
+        "label": "Text"
+      },
+      {
+        "component": "text",
+        "name": "linkTitle",
+        "label": "Title"
+      },
+      {
+        "component": "select",
+        "name": "linkType",
+        "label": "Type",
+        "options": [
+          {
+            "name": "default",
+            "value": ""
+          },
+          {
+            "name": "primary",
+            "value": "primary"
+          },
+          {
+            "name": "secondary",
+            "value": "secondary"
+          }
+        ]
       }
     ]
   }

--- a/models/_button.json
+++ b/models/_button.json
@@ -20,38 +20,7 @@
       "id": "button",
       "fields": [
         {
-          "component": "aem-content",
-          "name": "link",
-          "label": "Link"
-        },
-        {
-          "component": "text",
-          "name": "linkText",
-          "label": "Text"
-        },
-        {
-          "component": "text",
-          "name": "linkTitle",
-          "label": "Title"
-        },
-        {
-          "component": "select",
-          "name": "linkType",
-          "label": "Type",
-          "options": [
-            {
-              "name": "default",
-              "value": ""
-            },
-            {
-              "name": "primary",
-              "value": "primary"
-            },
-            {
-              "name": "secondary",
-              "value": "secondary"
-            }
-          ]
+          "...": "./_common.json#/button-fields"
         }
       ]
     }

--- a/models/_common.json
+++ b/models/_common.json
@@ -1,0 +1,38 @@
+{
+    "button-fields": [
+        {
+          "component": "aem-content",
+          "name": "link",
+          "label": "Link"
+        },
+        {
+          "component": "text",
+          "name": "linkText",
+          "label": "Text"
+        },
+        {
+          "component": "text",
+          "name": "linkTitle",
+          "label": "Title"
+        },
+        {
+          "component": "select",
+          "name": "linkType",
+          "label": "Type",
+          "options": [
+            {
+              "name": "default",
+              "value": ""
+            },
+            {
+              "name": "primary",
+              "value": "primary"
+            },
+            {
+              "name": "secondary",
+              "value": "secondary"
+            }
+          ]
+        }
+      ]
+}


### PR DESCRIPTION
PoC to reuse a set of fields defined for the UE on multiple blocks to avoid defining common field & combos over and over again. This can be helpful to define buttons with type & links, images with alt text etc.

Test URLs:
- Before: https://main--aem-boilerplate-xwalk--adobe-rnd.aem.live
- After: https://model-reuse--aem-boilerplate-xwalk--adobe-rnd.aem.page
