### PR TITLE
feat: add a way to manually set a section name to show in ContentTree

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -99,6 +99,12 @@
     "id": "section",
     "fields": [
       {
+        "component": "text",
+        "name": "name",
+        "label": "Section Name",
+        "description": "The label shown for this section in the Content Tree"
+      },
+      {
         "component": "multiselect",
         "name": "style",
         "label": "Style",

--- a/models/_section.json
+++ b/models/_section.json
@@ -20,6 +20,12 @@
       "id": "section",
       "fields": [
         {
+          "component": "text",
+          "name": "name",
+          "label": "Section Name",
+          "description": "The label shown for this section in the Content Tree"
+        },
+        {
           "component": "multiselect",
           "name": "style",
           "label": "Style",


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
