### PR TITLE
fix: 'lint:css' script supports deeper hierarchies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Starter project for Adobe Helix",
   "scripts": {
     "lint:js": "eslint . --ext .json,.js,.mjs",
-    "lint:css": "stylelint blocks/**/*.css styles/*.css",
+    "lint:css": "stylelint \"blocks/**/*.css\" \"styles/*.css\"",
     "lint": "npm run lint:js && npm run lint:css",
     "build:json": "npm-run-all -p build:json:models build:json:definitions build:json:filters",
     "build:json:models": "merge-json-cli -i 'models/_component-models.json' -o 'component-models.json'",


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #58 

Test URLs:
Before: https://main--aem-boilerplate-xwalk--adobe-rnd.hlx.live/
After: https://lint-css-on-wsl--aem-boilerplate-xwalk--adobe-rnd.hlx.live/

