### PR TITLE
fix: move decorateRichtext() calls to editor-support.js

### DIFF
--- a/scripts/editor-support-rte.js
+++ b/scripts/editor-support-rte.js
@@ -65,10 +65,3 @@ export function decorateRichtext(container = document) {
     }
   }
 }
-
-// in cases where the block decoration is not done in one synchronous iteration we need to listen
-// for new richtext-instrumented elements
-const observer = new MutationObserver(() => decorateRichtext());
-observer.observe(document, { attributeFilter: ['data-richtext-prop'], subtree: true });
-
-decorateRichtext();

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -109,3 +109,11 @@ function attachEventListners(main) {
 }
 
 attachEventListners(document.querySelector('main'));
+
+// decorate rich text
+// this has to happen after decorateMain(), and everythime decorateBlocks() is called
+decorateRichtext();
+// in cases where the block decoration is not done in one synchronous iteration we need to listen
+// for new richtext-instrumented elements. this happens for example when using experimentation.
+const observer = new MutationObserver(() => decorateRichtext());
+observer.observe(document, { attributeFilter: ['data-richtext-prop'], subtree: true });


### PR DESCRIPTION
In the past `editor-support-rte.js` was loaded as dependency of `editor-support.js` and executed only after `scripts.js`. It seems this behavior has changed and `editor-support-rte.js` is now executed immediately when loaded as dependency of `editor-support.js` even though `editor-support.js` is of `type=module` and executes in order after `scripts.js`. 

It is important to run `decorateRichtext()` only after `decorateMain()` has been called, as otherwise `decorateBlocks()`, specifically `wrapTextNodes()` is called after `decorateRichtext()` and would wrap the created `<div>` surrounding a richtext element with another `<p>`. 

Moving the invocation of `decorateRichtext()` makes sure it runs after `scripts.js` (in order of all scripts with type=module)