### PR TITLE
fix: restore section metadata processing

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -491,6 +491,24 @@ function decorateSections(main) {
     section.classList.add('section');
     section.dataset.sectionStatus = 'initialized';
     section.style.display = 'none';
+
+    // Process section metadata
+    const sectionMeta = section.querySelector('div.section-metadata');
+    if (sectionMeta) {
+      const meta = readBlockConfig(sectionMeta);
+      Object.keys(meta).forEach((key) => {
+        if (key === 'style') {
+          const styles = meta.style
+            .split(',')
+            .filter((style) => style)
+            .map((style) => toClassName(style.trim()));
+          styles.forEach((style) => section.classList.add(style));
+        } else {
+          section.dataset[toCamelCase(key)] = meta[key];
+        }
+      });
+      sectionMeta.parentNode.remove();
+    }
   });
 }
 


### PR DESCRIPTION
The processing of section metadata got removed from the adobe/aem-boilerplate with aem-lib 3.1.1

Until we don't render section metadata as data attributes with the AEMCS render pipeline we have to restore this decoration step.

https://fix-section-metadata--aem-boilerplate-xwalk--adobe-rnd.aem.page/